### PR TITLE
 Remove legacy field 'localVariables' from 'Function' construct.

### DIFF
--- a/include/ionir/construct/function.h
+++ b/include/ionir/construct/function.h
@@ -14,8 +14,6 @@ namespace ionir {
 
         ionshared::Ptr<FunctionBody> body;
 
-        PtrSymbolTable<LocalVariableDescriptor> localVariables;
-
         Function(
             ionshared::Ptr<Prototype> prototype,
             ionshared::Ptr<FunctionBody> body


### PR DESCRIPTION
 This fixes #23.

Seems a bit too easy but there were no other references and it compiles itself and input code just fine.