### PR TITLE
Fix TypeCheckPassTast::FunctionReturnTypeValueMismatch test

### DIFF
--- a/test/passes/type_check_pass.cpp
+++ b/test/passes/type_check_pass.cpp
@@ -86,11 +86,15 @@ TEST(TypeCheckPassTast, FunctionReturnTypeValueMismatch) {
         )
     );
 
-    /**
-     * When the return instruction is visited, a
-     */
-    EXPECT_THROW(
-        typeCheckPass->visitReturnInst(returnInst),
-        std::runtime_error
+	typeCheckPass->visitReturnInst(returnInst);
+
+	EXPECT_EQ(passContext->diagnostics->getSize(), 1);
+
+	ionshared::Diagnostic functionReturnValueTypeMismatchDiagnostic =
+		(*passContext->diagnostics.get())[0];
+
+	EXPECT_EQ(
+        functionReturnValueTypeMismatchDiagnostic.code.value(),
+        diagnostic::functionReturnValueTypeMismatch.code.value()
     );
 }


### PR DESCRIPTION
Fixes #25.

I have broken the test intentionally (before committing OFC) and it seems to work fine.